### PR TITLE
[#27] 음식 도메인 JPA 도입 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 
+	// JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/recipesns/RecipeSnsApplication.java
+++ b/src/main/java/com/recipesns/RecipeSnsApplication.java
@@ -2,9 +2,11 @@ package com.recipesns;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
+@EnableJpaAuditing
 @SpringBootApplication
 public class RecipeSnsApplication {
 

--- a/src/main/java/com/recipesns/core/model/BaseEntity.java
+++ b/src/main/java/com/recipesns/core/model/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.recipesns.core.model;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/recipesns/core/model/food/Food.java
+++ b/src/main/java/com/recipesns/core/model/food/Food.java
@@ -1,15 +1,19 @@
 package com.recipesns.core.model.food;
 
-import lombok.Getter;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.relational.core.mapping.Table;
-
-import java.time.LocalDateTime;
+import com.recipesns.core.model.BaseEntity;
+import com.recipesns.core.service.food.provider.responce.FoodData;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Getter
-@Table("FOOD")
-public class Food {
+@Setter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Food extends BaseEntity {
+
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "food_id")
     private Long id;
     private String foodName;
     private Integer foodSize;
@@ -18,9 +22,8 @@ public class Food {
     private double protein;
     private double calorie;
     private double fat;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
 
+    @Builder
     public Food(String foodName, Integer foodSize, String foodCode, double carbohydrate, double protein, double fat, double calorie) {
         this.foodName = foodName;
         this.foodSize = foodSize;
@@ -29,7 +32,15 @@ public class Food {
         this.protein = protein;
         this.fat = fat;
         this.calorie = calorie;
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateFood(FoodData foodData) {
+        this.foodName = foodData.getFoodName();
+        this.foodSize = foodData.getFoodSize();
+        this.foodCode = foodData.getFoodCode();
+        this.carbohydrate = foodData.getCarbohydrate();
+        this.protein = foodData.getProtein();
+        this.fat = foodData.getFat();
+        this.calorie = foodData.getCalorie();
     }
 }

--- a/src/main/java/com/recipesns/repository/food/JpaFoodRepository.java
+++ b/src/main/java/com/recipesns/repository/food/JpaFoodRepository.java
@@ -2,12 +2,11 @@ package com.recipesns.repository.food;
 
 import com.recipesns.core.model.food.Food;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface SpringDataJdbcFoodRepository extends CrudRepository<Food, Long> {
-    Food findByFoodCode(String foodCode);
-    List<Food> findAll(Pageable pageable);
+public interface JpaFoodRepository extends JpaRepository<Food, Long> {
     List<Food> findByFoodNameContaining(String foodName, Pageable pageable);
+    List<Food> findAllByFoodCodeIn(List<String> foodCodes);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,10 @@ spring:
   config:
     activate:
       on-profile: local
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
 logging:
   level:
     org.springframework.jdbc.core: DEBUG
@@ -27,6 +31,10 @@ spring:
     url: jdbc:h2:mem:~/test;MODE=MYSQL;
     username: sa
     password:
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
   sql:
     init:
       mode: always
@@ -35,8 +43,10 @@ spring:
 
 logging:
   level:
-    org.springframework.jdbc.core: DEBUG
-    org.springframework.jdbc.support: DEBUG
+    org.hibernate.sql: debug
+    org.hibernate.type: trace
+#    org.springframework.jdbc.core: DEBUG
+#    org.springframework.jdbc.support: DEBUG
 
 ---
 spring:

--- a/src/test/java/com/recipesns/core/model/food/FoodTest.java
+++ b/src/test/java/com/recipesns/core/model/food/FoodTest.java
@@ -1,0 +1,35 @@
+package com.recipesns.core.model.food;
+
+import com.recipesns.core.service.food.provider.responce.FoodData;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class FoodTest {
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Test
+    @Rollback(false)
+    void test() {
+        Food food = Food.builder()
+                .foodName("음식 이름1")
+                .foodSize(140)
+                .foodCode("DS1234")
+                .carbohydrate(50.2)
+                .protein(30.2)
+                .fat(12)
+                .calorie(511)
+                .build();
+
+        entityManager.persist(food);
+        FoodData foodData1 = new FoodData("음식 이름12", 141, "DS1234", 50.2, 30.2, 12, 511);
+        food.updateFood(foodData1);
+    }
+}

--- a/src/test/java/com/recipesns/repository/food/JdbcFoodRepositoryTest.java
+++ b/src/test/java/com/recipesns/repository/food/JdbcFoodRepositoryTest.java
@@ -6,6 +6,7 @@ import com.recipesns.core.service.food.provider.responce.FoodData;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +38,7 @@ class JdbcFoodRepositoryTest {
     }
 
     @Test
+    @Rollback(false)
     void update() {
         Food food1 = new Food("음식 이름1", 140, "DS1234", 50.2, 30.2, 12, 511);
         Food food2 = new Food("음식 이름2", 140, "DS1235", 50.2, 30.2, 12, 511);
@@ -73,7 +75,7 @@ class JdbcFoodRepositoryTest {
         this.jdbcFoodRepository.save(food3);
 
         List<Food> foodList1 = this.jdbcFoodRepository.findAll(new FoodSearchRequestDto(null, 1, 10));
-        assertThat(foodList1.size()).isEqualTo(8);
+        assertThat(foodList1.size()).isEqualTo(3);
 
         List<Food> foodList2 = this.jdbcFoodRepository.findAll(new FoodSearchRequestDto("이름1", 1, 1));
         assertThat(foodList2.size()).isEqualTo(1);


### PR DESCRIPTION
## 작업내용
- JPA  config 설정
- Food Entity 작업
- BaseEntity 만들어 생성날짜와 수정날짜를 모든 Entity에서 사용할 수 있도록 작업
- 기존에 Spring Data Jdbc를 사용한 로직 JpaFoodRepository로 작업